### PR TITLE
Northflank deprecation

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -293,10 +293,6 @@ Click on one of the links below to view further instructions for your preferred 
 
 A platform as a service (PaaS) that offers relatively low cost plans, which allows you to host Modmail for little without any downtime. A credit card is required for payment. Their UI is very simple and easy for beginners to quickly deploy and run your Modmail bot on. You can learn more about their plans and pricing by clicking [here](https://railway.app/pricing).&#x20;
 
-### [Northflank](https://northflank.com/) (free/paid)
-
-A PaaS like Railway but with more advanced UI and more features. Does require credit card for verification but has a dedicated free tier that has no hourly limit. Learn more about their free tier and pricing by clicking [here](https://northflank.com/pricing).
-
 ### [Local Hosting](local-hosting-vps/) (free)
 
 If you have an old PC, a Raspberry Pi, or a Linux box that you're able to keep online 24/7, you can also host Modmail with your own machine at home. Since Modmail doesn't require intensive resources to run, you can get by with a system having as low as 1GB of RAM. Setting it up can be quite advanced but you have complete control over your bot instance. Refer to our local hosting guide supporting a few popular OSes by clicking [here](./#local-hosting-free).

--- a/installation/community-guides.md
+++ b/installation/community-guides.md
@@ -12,7 +12,11 @@ Community guides are not verified by the Modmail team, so use them at your own r
 
 An online code execution environment that costs $7 USD per month. However, hosting on Replit is often unstable, and thus not recommended. For the up-to-date pricing info check out their [pricing](https://replit.com/pricing) page.
 
-## [Northflank](https://blog.project-mei.xyz/2023/04/11/hosting-discord-modmail-on-northflank/) Guide by raidensakura
+## [Northflank](https://project-mei.xyz/blog/modmail-on-northflank/) Guide by raidensakura
+
+{% hint style="danger" %}
+Due to uptime and reliability issues on Northflank, the creator of this guide and the Modmail team has deprecated this hosting method. We strongly recommend to use a different host. More information can be read [here](https://discord.com/channels/1079074933008781362/1079077917771964426/1391562969443340360).
+{% endhint %}
 
 Northflank is a Platform as a Service (PaaS) like Railway that offers abilities to run micro-services like bots, schedule jobs that run periodically and databases with a powerful UI, API and CLI. Their panel is a bit more advanced as compared to Railway but comes with the perk of more customization and features. You will need a valid payment method to verify your account, but will unlock a free tier project that's separated from paid resources. They will not charge your card if you go over resource usage as you have limited allocation per service.
 


### PR DESCRIPTION
Removes northflank from the Installation guide and adds a deprecation warning. To avoid users try to install there.