### PR TITLE
Minor macOS improvements

### DIFF
--- a/installation/local-hosting-vps/macos.md
+++ b/installation/local-hosting-vps/macos.md
@@ -27,7 +27,7 @@ All code blocks should be executed in zsh or bash and line by line unless specif
 To install these dependencies, we will be using Terminal (zsh or bash):
 
 ```bash
-brew install python3 cairo libxml2 libxslt libffi
+brew install git python@3.10 cairo libxml2 libxslt libffi
 pip3 install cairosvg
 ```
 


### PR DESCRIPTION
- Added git to brew command
- Explicitly set Python's version to 3.10 (brew defaults to the latest formulae which is Python 3.14)